### PR TITLE
.gitmodules: remove ESR branch from meta-balena

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,6 @@
 [submodule "layers/meta-balena"]
 	path = layers/meta-balena
 	url = https://github.com/balena-os/meta-balena.git
-	branch = 2.88.x
 [submodule "balena-yocto-scripts"]
 	path = balena-yocto-scripts
 	url = https://github.com/balena-os/balena-yocto-scripts.git


### PR DESCRIPTION
This prevents meta-balena from updating automatically for this repository.

ESR releases are managed with independent branches.

Changelog-entry: remove branch specification from meta-balena submodule
Signed-off-by: Alex Gonzalez <alexg@balena.io>